### PR TITLE
Scaffold prompd ai command (Phase 1)

### DIFF
--- a/typescript/src/commands/ai.ts
+++ b/typescript/src/commands/ai.ts
@@ -1,0 +1,98 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { getStatus } from '../lib/ai/daemon';
+
+export function createAICommand(): Command {
+  const command = new Command('ai');
+  command.description('Manage the on-device Prompd AI runtime');
+
+  command.addCommand(createInstallSubcommand());
+  command.addCommand(createUninstallSubcommand());
+  command.addCommand(createStartSubcommand());
+  command.addCommand(createStopSubcommand());
+  command.addCommand(createStatusSubcommand());
+
+  return command;
+}
+
+function createInstallSubcommand(): Command {
+  const cmd = new Command('install');
+  cmd
+    .description('Download and install a model into the local catalog')
+    .option('-m, --model <name>', 'Model to install (e.g., gemma-4-e4b-q4, prompd-prmd@0.0.1)')
+    .option('-y, --yes', 'Assume yes to all prompts (headless mode)')
+    .action(async (opts: { model?: string; yes?: boolean }) => {
+      console.log(chalk.yellow('Phase 1 scaffolding — install not yet implemented.'));
+      console.log(`  model:    ${opts.model ?? chalk.gray('(not specified)')}`);
+      console.log(`  headless: ${opts.yes ? 'yes' : 'no'}`);
+    });
+  return cmd;
+}
+
+function createUninstallSubcommand(): Command {
+  const cmd = new Command('uninstall');
+  cmd
+    .description('Remove a model from the catalog, or wipe the entire runtime if no --model is given')
+    .option('-m, --model <name>', 'Specific model to remove (omit to wipe everything)')
+    .option('-y, --yes', 'Assume yes to all prompts (headless mode)')
+    .action(async (opts: { model?: string; yes?: boolean }) => {
+      console.log(chalk.yellow('Phase 1 scaffolding — uninstall not yet implemented.'));
+      console.log(`  model:    ${opts.model ?? chalk.gray('(wipe everything)')}`);
+      console.log(`  headless: ${opts.yes ? 'yes' : 'no'}`);
+    });
+  return cmd;
+}
+
+function createStartSubcommand(): Command {
+  const cmd = new Command('start');
+  cmd
+    .description('Start the local AI daemon')
+    .option('-m, --model <name>', 'Model to serve (defaults to the first-installed or user-configured default)')
+    .action(async (opts: { model?: string }) => {
+      console.log(chalk.yellow('Phase 1 scaffolding — start not yet implemented.'));
+      console.log(`  model: ${opts.model ?? chalk.gray('(default)')}`);
+    });
+  return cmd;
+}
+
+function createStopSubcommand(): Command {
+  const cmd = new Command('stop');
+  cmd
+    .description('Stop the running local AI daemon')
+    .action(async () => {
+      console.log(chalk.yellow('Phase 1 scaffolding — stop not yet implemented.'));
+    });
+  return cmd;
+}
+
+function createStatusSubcommand(): Command {
+  const cmd = new Command('status');
+  cmd
+    .description('Show daemon state and installed-models catalog')
+    .action(async () => {
+      const status = await getStatus();
+
+      if (status.running) {
+        console.log(chalk.green('Running'));
+        console.log(`  model:   ${status.model}`);
+        console.log(`  port:    ${status.port}`);
+        console.log(`  pid:     ${status.pid}`);
+        console.log(`  started: ${status.startedAt}`);
+        console.log(`  binary:  ${status.binaryPath}`);
+      } else {
+        console.log(chalk.gray('Not running'));
+      }
+
+      console.log();
+      console.log(chalk.bold(`Installed models (${status.installedModels.length}):`));
+      if (status.installedModels.length === 0) {
+        console.log(chalk.gray('  (none)'));
+      } else {
+        for (const m of status.installedModels) {
+          const tag = m.isDefault ? chalk.cyan(' [default]') : '';
+          console.log(`  ${m.name}${tag}`);
+        }
+      }
+    });
+  return cmd;
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -26,6 +26,7 @@ import { createUninstallCommand } from './commands/uninstall';
 import { createNamespaceCommand } from './commands/namespace';
 import { createDepsCommand } from './commands/deps';
 import { createWorkflowCommand } from './commands/workflow';
+import { createAICommand } from './commands/ai';
 
 const program = new Command();
 
@@ -52,6 +53,7 @@ program.addCommand(createVersionCommand());
 program.addCommand(createGitCommand());
 program.addCommand(createMCPCommand());
 program.addCommand(createWorkflowCommand());
+program.addCommand(createAICommand());
 
 // Registry operations (top-level for convenience)
 program.addCommand(createLoginCommand());

--- a/typescript/src/lib/ai/catalog.ts
+++ b/typescript/src/lib/ai/catalog.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs-extra';
+import { aiRoot, catalogPath } from './paths';
+import { Catalog, ModelEntry } from './types';
+
+const EMPTY_CATALOG: Catalog = { version: 1, models: [] };
+
+export async function loadCatalog(): Promise<Catalog> {
+  const p = catalogPath();
+  if (!(await fs.pathExists(p))) {
+    return { version: 1, models: [] };
+  }
+  try {
+    const raw = await fs.readJSON(p);
+    if (!raw || raw.version !== 1 || !Array.isArray(raw.models)) {
+      return { version: 1, models: [] };
+    }
+    return raw as Catalog;
+  } catch {
+    return { version: 1, models: [] };
+  }
+}
+
+export async function saveCatalog(catalog: Catalog): Promise<void> {
+  await fs.ensureDir(aiRoot());
+  await fs.writeJSON(catalogPath(), catalog, { spaces: 2 });
+}
+
+export async function findModel(name: string): Promise<ModelEntry | undefined> {
+  const catalog = await loadCatalog();
+  return catalog.models.find(m => m.name === name);
+}
+
+export async function getDefaultModel(): Promise<ModelEntry | undefined> {
+  const catalog = await loadCatalog();
+  return catalog.models.find(m => m.isDefault) ?? catalog.models[0];
+}

--- a/typescript/src/lib/ai/daemon.ts
+++ b/typescript/src/lib/ai/daemon.ts
@@ -1,0 +1,65 @@
+import * as fs from 'fs-extra';
+import { lockPath } from './paths';
+import { DaemonLock, DaemonStatus } from './types';
+import { loadCatalog } from './catalog';
+
+export async function readLock(): Promise<DaemonLock | null> {
+  const p = lockPath();
+  if (!(await fs.pathExists(p))) return null;
+  try {
+    const raw = await fs.readJSON(p);
+    if (
+      typeof raw?.port !== 'number' ||
+      typeof raw?.pid !== 'number' ||
+      typeof raw?.model !== 'string' ||
+      typeof raw?.startedAt !== 'string' ||
+      typeof raw?.binaryPath !== 'string'
+    ) {
+      return null;
+    }
+    return raw as DaemonLock;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearLock(): Promise<void> {
+  const p = lockPath();
+  if (await fs.pathExists(p)) {
+    await fs.remove(p);
+  }
+}
+
+export function isPidAlive(pid: number): boolean {
+  try {
+    // signal 0 performs an existence check without sending a real signal
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getStatus(): Promise<DaemonStatus> {
+  const catalog = await loadCatalog();
+  const lock = await readLock();
+
+  if (!lock) {
+    return { running: false, installedModels: catalog.models };
+  }
+
+  if (!isPidAlive(lock.pid)) {
+    await clearLock();
+    return { running: false, installedModels: catalog.models };
+  }
+
+  return {
+    running: true,
+    model: lock.model,
+    port: lock.port,
+    pid: lock.pid,
+    startedAt: lock.startedAt,
+    binaryPath: lock.binaryPath,
+    installedModels: catalog.models,
+  };
+}

--- a/typescript/src/lib/ai/paths.ts
+++ b/typescript/src/lib/ai/paths.ts
@@ -1,0 +1,34 @@
+import * as path from 'path';
+import * as os from 'os';
+
+export function aiRoot(): string {
+  return path.join(os.homedir(), '.prompd', 'ai');
+}
+
+export function binDir(): string {
+  return path.join(aiRoot(), 'bin');
+}
+
+export function modelsDir(): string {
+  return path.join(aiRoot(), 'models');
+}
+
+export function adaptersDir(): string {
+  return path.join(aiRoot(), 'adapters');
+}
+
+export function configPath(): string {
+  return path.join(aiRoot(), 'config.json');
+}
+
+export function pidPath(): string {
+  return path.join(aiRoot(), 'daemon.pid');
+}
+
+export function lockPath(): string {
+  return path.join(aiRoot(), 'daemon.lock');
+}
+
+export function catalogPath(): string {
+  return path.join(aiRoot(), 'catalog.json');
+}

--- a/typescript/src/lib/ai/types.ts
+++ b/typescript/src/lib/ai/types.ts
@@ -1,0 +1,36 @@
+export interface ModelEntry {
+  name: string;
+  family: string;
+  size: string;
+  quantization: string;
+  variant?: string;
+  version?: string;
+  weightsPath: string;
+  sizeBytes: number;
+  sha256: string;
+  installedAt: string;
+  isDefault: boolean;
+}
+
+export interface Catalog {
+  version: 1;
+  models: ModelEntry[];
+}
+
+export interface DaemonLock {
+  port: number;
+  pid: number;
+  model: string;
+  startedAt: string;
+  binaryPath: string;
+}
+
+export interface DaemonStatus {
+  running: boolean;
+  model?: string;
+  port?: number;
+  pid?: number;
+  startedAt?: string;
+  binaryPath?: string;
+  installedModels: ModelEntry[];
+}

--- a/typescript/tests/ai.test.ts
+++ b/typescript/tests/ai.test.ts
@@ -1,0 +1,140 @@
+jest.mock('../src/lib/ai/paths', () => {
+  const actualPath = jest.requireActual<typeof import('path')>('path');
+  const actualOs = jest.requireActual<typeof import('os')>('os');
+  const actualFs = jest.requireActual<typeof import('fs-extra')>('fs-extra');
+  const tmpRoot: string = actualFs.mkdtempSync(actualPath.join(actualOs.tmpdir(), 'prompd-ai-test-'));
+  return {
+    aiRoot: () => tmpRoot,
+    binDir: () => actualPath.join(tmpRoot, 'bin'),
+    modelsDir: () => actualPath.join(tmpRoot, 'models'),
+    adaptersDir: () => actualPath.join(tmpRoot, 'adapters'),
+    configPath: () => actualPath.join(tmpRoot, 'config.json'),
+    pidPath: () => actualPath.join(tmpRoot, 'daemon.pid'),
+    lockPath: () => actualPath.join(tmpRoot, 'daemon.lock'),
+    catalogPath: () => actualPath.join(tmpRoot, 'catalog.json'),
+  };
+});
+
+import * as fs from 'fs-extra';
+import { loadCatalog, saveCatalog, findModel, getDefaultModel } from '../src/lib/ai/catalog';
+import { getStatus, clearLock } from '../src/lib/ai/daemon';
+import { catalogPath, lockPath, aiRoot } from '../src/lib/ai/paths';
+
+describe('prompd ai — catalog and daemon scaffolding', () => {
+  afterAll(() => {
+    fs.removeSync(aiRoot());
+  });
+
+  beforeEach(async () => {
+    await clearLock();
+    if (await fs.pathExists(catalogPath())) {
+      await fs.remove(catalogPath());
+    }
+  });
+
+  describe('catalog', () => {
+    it('returns empty catalog when file does not exist', async () => {
+      const catalog = await loadCatalog();
+      expect(catalog).toEqual({ version: 1, models: [] });
+    });
+
+    it('round-trips a saved catalog', async () => {
+      await saveCatalog({
+        version: 1,
+        models: [
+          {
+            name: 'gemma-4-e4b-q4',
+            family: 'gemma-4',
+            size: 'e4b',
+            quantization: 'q4',
+            weightsPath: '/tmp/weights.gguf',
+            sizeBytes: 2_500_000_000,
+            sha256: 'abc123',
+            installedAt: '2026-04-19T00:00:00.000Z',
+            isDefault: true,
+          },
+        ],
+      });
+
+      const loaded = await loadCatalog();
+      expect(loaded.models).toHaveLength(1);
+      expect(loaded.models[0].name).toBe('gemma-4-e4b-q4');
+    });
+
+    it('findModel returns the matching entry, undefined when missing', async () => {
+      await saveCatalog({
+        version: 1,
+        models: [makeModel('model-a', false), makeModel('model-b', true)],
+      });
+
+      expect((await findModel('model-b'))?.isDefault).toBe(true);
+      expect(await findModel('nope')).toBeUndefined();
+    });
+
+    it('getDefaultModel prefers explicit default, falls back to first', async () => {
+      await saveCatalog({
+        version: 1,
+        models: [makeModel('a', false), makeModel('b', true)],
+      });
+      expect((await getDefaultModel())?.name).toBe('b');
+
+      await saveCatalog({
+        version: 1,
+        models: [makeModel('a', false), makeModel('c', false)],
+      });
+      expect((await getDefaultModel())?.name).toBe('a');
+    });
+
+    it('gracefully handles a corrupt catalog file', async () => {
+      await fs.ensureFile(catalogPath());
+      await fs.writeFile(catalogPath(), '{ not valid json', 'utf-8');
+      const catalog = await loadCatalog();
+      expect(catalog).toEqual({ version: 1, models: [] });
+    });
+  });
+
+  describe('daemon status', () => {
+    it('reports not running when no lock file exists', async () => {
+      const status = await getStatus();
+      expect(status.running).toBe(false);
+      expect(status.installedModels).toEqual([]);
+    });
+
+    it('reports not running and clears a stale lock (dead pid)', async () => {
+      await fs.ensureFile(lockPath());
+      await fs.writeJSON(lockPath(), {
+        port: 11434,
+        pid: 999999999,
+        model: 'gemma-4-e4b-q4',
+        startedAt: '2026-04-19T00:00:00.000Z',
+        binaryPath: '/nonexistent/llama-server',
+      });
+
+      const status = await getStatus();
+      expect(status.running).toBe(false);
+      expect(await fs.pathExists(lockPath())).toBe(false);
+    });
+
+    it('includes installed-models list even when not running', async () => {
+      await saveCatalog({ version: 1, models: [makeModel('x', true)] });
+      const status = await getStatus();
+      expect(status.running).toBe(false);
+      expect(status.installedModels).toHaveLength(1);
+      expect(status.installedModels[0].name).toBe('x');
+    });
+  });
+});
+
+function makeModel(name: string, isDefault: boolean) {
+  return {
+    name,
+    family: 'test',
+    size: 's',
+    quantization: 'q4',
+    weightsPath: '',
+    sizeBytes: 0,
+    sha256: '',
+    installedAt: '',
+    isDefault,
+  };
+}


### PR DESCRIPTION
## Summary
First PR in the Prompd AI local-runtime workstream. Wires up the `prompd ai` command with all five verbs (install / uninstall / start / stop / status) plus supporting lib modules, but only implements the non-destructive read path.

## What's in this PR
**New command:** [typescript/src/commands/ai.ts](typescript/src/commands/ai.ts) — top-level `ai` with five subcommands, flag parsing (`--model`, `-y/--yes`) wired up via commander.

**New lib modules at [typescript/src/lib/ai/](typescript/src/lib/ai/):**
- `paths.ts` — resolves `~/.prompd/ai/` and subdirs
- `types.ts` — `ModelEntry`, `Catalog`, `DaemonLock`, `DaemonStatus`
- `catalog.ts` — load/save, `findModel`, `getDefaultModel` (explicit-default → first-installed fallback)
- `daemon.ts` — `readLock`, `clearLock`, `isPidAlive`, `getStatus` with stale-lock cleanup

**Behavior in this PR:**
- `prompd ai --help` — clean output, all 5 verbs listed
- `prompd ai status` — fully functional; reads catalog + lock file, clears stale locks, prints running state and installed-models list
- `prompd ai install / uninstall / start / stop` — print "Phase 1 scaffolding — not yet implemented" with their parsed flags echoed back

**Tests:** 8 new tests covering catalog round-trip, default-model resolution, corrupt-file handling, not-running status, and stale-lock cleanup on dead PIDs. Full suite passes (21 suites, 339 pass, 5 skipped).

## Why this shape
Small, reviewable PR. Commits the command surface (names, flags, help text) and proves the plumbing without making the big llama-server bundling decision. Follow-ups will fill in `install` (downloader + manifest), `start` (llama-server spawn + lock write), etc.

## Why `prompd ai`
Chosen in [Prompd/prompd-app#46](https://github.com/Prompd/prompd-app/pull/46). The AIDEN / AI Fox codenames were dropped — Aiden-space is crowded in the AI-assistant market and `prompd ai` is intuitive in `--help` output + trademark-collision-proof.

## Plan
Full plan in [prompd-app/docs/PROMPD-AI-PLAN.md](https://github.com/Prompd/prompd-app/blob/main/docs/PROMPD-AI-PLAN.md).

## Test plan
- [ ] `npm run build` succeeds
- [ ] `npx jest` passes (21 suites, 339 tests)
- [ ] `node ./bin/prompd.js ai --help` renders cleanly
- [ ] `node ./bin/prompd.js ai status` reports "Not running" and "(none)" on a fresh machine
- [ ] `node ./bin/prompd.js ai install --model gemma-4-e4b-q4 -y` echoes the parsed flags

Generated with [Claude Code](https://claude.com/claude-code)